### PR TITLE
Fix randint problem with float

### DIFF
--- a/HackRF/JamRF.py
+++ b/HackRF/JamRF.py
@@ -247,7 +247,7 @@ def sweeping(init_freq, lst_freq, options):
 
 def hopping(init_freq, lst_freq, options):
     n_channels = (lst_freq - init_freq) // (options.get("ch_dist")*10e5)
-    channel = randint(1, n_channels + 1)
+    channel = int(randint(1, n_channels + 1))
     t_j, t_s = enable_energy_savings(options.get("t_jamming"), options)
     start_time = time.time()
     while True:
@@ -256,7 +256,7 @@ def hopping(init_freq, lst_freq, options):
         m_flag = jamming(my_jammer, freq, options)
         time.sleep(t_s)
         if m_flag == 0:
-            channel = randint(1, n_channels + 1)
+            channel = int(randint(1, n_channels + 1))
         jamming_time_per_run = time.time() - start_time
         if jamming_time_per_run >= options.get("duration"):
             break

--- a/HackRF/jamRF_v1.py
+++ b/HackRF/jamRF_v1.py
@@ -303,7 +303,7 @@ if __name__ == "__main__":
     elif jammer == 3:
         start_time = time.time()
         while True:
-            channel = randint(1, n_channels + 1)
+            channel = int(randint(1, int(n_channels) + 1))
             freq = set_frequency(channel, ch_dist)
             if jamming == 1:
                 # Jam


### PR DESCRIPTION
Without this fix, an exception is thrown about a float somewhere (input of `randint` ?). 
I don't have time to investigate, but this mitigate the exception and seems to work as intended.